### PR TITLE
`Revert "added REVRobotics and NavX Vendor Libraries"

### DIFF
--- a/vendordeps/WPILibNewCommands.json
+++ b/vendordeps/WPILibNewCommands.json
@@ -1,0 +1,37 @@
+{
+  "fileName": "WPILibNewCommands.json",
+  "name": "WPILib-New-Commands",
+  "version": "2020.0.0",
+  "uuid": "111e20f7-815e-48f8-9dd6-e675ce75b266",
+  "mavenUrls": [],
+  "jsonUrl": "",
+  "javaDependencies": [
+      {
+          "groupId": "edu.wpi.first.wpilibNewCommands",
+          "artifactId": "wpilibNewCommands-java",
+          "version": "wpilib"
+      }
+  ],
+  "jniDependencies": [],
+  "cppDependencies": [
+      {
+          "groupId": "edu.wpi.first.wpilibNewCommands",
+          "artifactId": "wpilibNewCommands-cpp",
+          "version": "wpilib",
+          "libName": "wpilibNewCommands",
+          "headerClassifier": "headers",
+          "sourcesClassifier": "sources",
+          "sharedLibrary": true,
+          "skipInvalidPlatforms": true,
+          "binaryPlatforms": [
+              "linuxathena",
+              "linuxraspbian",
+              "linuxaarch64bionic",
+              "windowsx86-64",
+              "windowsx86",
+              "linuxx86-64",
+              "osxx86-64"
+          ]
+      }
+  ]
+}


### PR DESCRIPTION
This reverts commit f78cb752f553de457f0389f64fe5662d5e165c45.

This wasn't done right and needs to be reverted